### PR TITLE
Create code formatting tip watcher.

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ import { IWatcher } from 'definitions/IWatcher'
 import { IReaction } from 'definitions/IReaction'
 import * as HELP_COMMANDS from 'help/commands'
 import * as USER_COMMANDS from 'user/commands'
+import * as USER_WATCHERS from 'user/watchers'
 import * as USER_REACTIONS from 'user/reactions'
 import { keepAlive } from './keepAlive'
 
@@ -34,6 +35,7 @@ client.once('ready', () => {
 
   // register watchers
   // registerWatcher(WATCHER_ONLINE_USERS);
+  registerWatcher(USER_WATCHERS.WATCHER_UNFORMATTED_CODE)
 
   // register reactions
   registerReactionAdd(USER_REACTIONS.REACTION_ADD_SIGN)

--- a/src/user/watchers.ts
+++ b/src/user/watchers.ts
@@ -1,0 +1,26 @@
+import { IWatcher } from 'definitions/IWatcher'
+
+const CODE_REGEX = /```\n/
+
+export const WATCHER_UNFORMATTED_CODE: IWatcher = {
+  name: 'unformatted code',
+  handler: (client) => async () => {
+    client.on('message', (msg) => {
+      if (msg.author.bot || !CODE_REGEX.test(msg.content)) return
+
+      msg.channel.send([
+        '**TIP**: Discord supports syntax highlighting by decorating the first `` ``` `` of a code block with a language id (ts, js, jsx, css, html, bash).',
+        '```',
+        '`\u200b`\u200b`ts',
+        '// input',
+        'console.log(\'Hello World\')',
+        '`\u200b`\u200b`',
+        '```',
+        '```ts',
+        '// output',
+        'console.log(\'Hello World\')',
+        '```',
+      ].join('\n'))
+    })
+  },
+}


### PR DESCRIPTION
Created a watcher that listens to messages for triple backticks ``` followed by a line break (no specified language).

![image](https://user-images.githubusercontent.com/23324155/100363653-ad255d00-2fc2-11eb-99a0-f4a11787c185.png)

Possible conflicts
 - inline code blocks
 - invalid markdown

closes #2