### PR TITLE
Fix formatting watcher false positives

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -10,7 +10,7 @@ import { IWatcher } from 'definitions/IWatcher'
 import { IReaction } from 'definitions/IReaction'
 import * as HELP_COMMANDS from 'help/commands'
 import * as USER_COMMANDS from 'user/commands'
-// import * as USER_WATCHERS from 'user/watchers'
+import * as USER_WATCHERS from 'user/watchers'
 import * as USER_REACTIONS from 'user/reactions'
 import { keepAlive } from './keepAlive'
 
@@ -34,8 +34,7 @@ client.once('ready', () => {
   registerCommand(USER_COMMANDS.COMMAND_ROLE_REMOVE)
 
   // register watchers
-  // temporarily disabling this watcher while I consider the frequency.
-  // registerWatcher(USER_WATCHERS.WATCHER_UNFORMATTED_CODE)
+  registerWatcher(USER_WATCHERS.WATCHER_UNFORMATTED_CODE)
 
   // register reactions
   registerReactionAdd(USER_REACTIONS.REACTION_ADD_SIGN)

--- a/src/user/watchers.ts
+++ b/src/user/watchers.ts
@@ -1,28 +1,38 @@
 import { IWatcher } from 'definitions/IWatcher'
 
+let codeTipCount = 0
+
 export const WATCHER_UNFORMATTED_CODE: IWatcher = {
   name: 'unformatted code',
   handler: (client) => async () => {
     client.on('message', (msg) => {
+      const codeblocks = msg.content.match(/```(.|\n)*?```/g)
+      const invalidCode = codeblocks?.some((codeblock) => /```\n((.|\n)*?)```/g.test(codeblock))
+
       // escape early if codeblock already has an id.
-      if (msg.author.bot || !/```\n/.test(msg.content)) return
-      let result = ''
-      // eslint-disable-next-line prettier/prettier
-      result += '**TIP**: Discord supports syntax highlighting by decorating the first **\\`\\`\\`** of a code block with a language id (ts, js, jsx, css, html, bash).\n'
+      if (msg.author.bot || !invalidCode) return
 
-      // eslint-disable-next-line prettier/prettier
-      result += '\\`\\`\\`ts\n'
-      result += '// input\n'
-      result += `console.log('Hello World')\n`
-      // eslint-disable-next-line prettier/prettier
-      result += '\\`\\`\\`\n'
+      if (codeTipCount % 3 === 0) {
+        let result = ''
+        // eslint-disable-next-line prettier/prettier
+        result += '**TIP**: Discord supports syntax highlighting by decorating the first **\\`\\`\\`** of a code block with a language id (ts, js, jsx, css, html, bash).\n'
 
-      result += '```ts\n'
-      result += '// output\n'
-      result += `console.log('Hello World')\n`
-      result += '```\n'
+        // eslint-disable-next-line prettier/prettier
+        result += '\\`\\`\\`ts\n'
+        result += '// input\n'
+        result += `console.log('Hello World')\n`
+        // eslint-disable-next-line prettier/prettier
+        result += '\\`\\`\\`\n'
 
-      msg.channel.send(result)
+        result += '```ts\n'
+        result += '// output\n'
+        result += `console.log('Hello World')\n`
+        result += '```\n'
+
+        msg.channel.send(result)
+      }
+
+      codeTipCount++
     })
   },
 }

--- a/src/user/watchers.ts
+++ b/src/user/watchers.ts
@@ -10,29 +10,24 @@ export const WATCHER_UNFORMATTED_CODE: IWatcher = {
       const invalidCode = codeblocks?.some((codeblock) => /```\n((.|\n)*?)```/g.test(codeblock))
 
       // escape early if codeblock already has an id.
-      if (msg.author.bot || !invalidCode) return
-
-      if (codeTipCount % 3 === 0) {
-        let result = ''
-        // eslint-disable-next-line prettier/prettier
-        result += '**TIP**: Discord supports syntax highlighting by decorating the first **\\`\\`\\`** of a code block with a language id (ts, js, jsx, css, html, bash).\n'
-
-        // eslint-disable-next-line prettier/prettier
-        result += '\\`\\`\\`ts\n'
-        result += '// input\n'
-        result += `console.log('Hello World')\n`
-        // eslint-disable-next-line prettier/prettier
-        result += '\\`\\`\\`\n'
-
-        result += '```ts\n'
-        result += '// output\n'
-        result += `console.log('Hello World')\n`
-        result += '```\n'
-
-        msg.channel.send(result)
-      }
-
+      if (msg.author.bot || !invalidCode ) return
+      if (!!(codeTipCount % 3)) return
       codeTipCount++
+      let result = ''
+      // eslint-disable-next-line prettier/prettier
+      result += '**TIP**: Discord supports syntax highlighting. Decorate the first **\\`\\`\\`** of a code block with a language id (ts, js, jsx, css, html, bash).\n'
+
+      // eslint-disable-next-line prettier/prettier
+      result += '\\`\\`\\`ts\n'
+      result += `console.log('input', 'Hello World')\n`
+      // eslint-disable-next-line prettier/prettier
+      result += '\\`\\`\\`\n'
+
+      result += '```ts\n'
+      result += `console.log('output', 'Hello World')\n`
+      result += '```\n'
+
+      msg.channel.send(result)
     })
   },
 }


### PR DESCRIPTION
This pull request addresses the code formatting watcher's issue with detecting both the starting and ending markdown for code blocks as false positives.

I expanded the code validator regex to isolate code blocks to validate.
I have also spaced out messages to send every third positive.

closes #4 